### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+  secrets: read
+  actions: read
+
 env:
   COMPOSER_NO_INTERACTION: 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/volt-test/laravel-performance-testing/security/code-scanning/5](https://github.com/volt-test/laravel-performance-testing/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are appropriate:

- `contents: read` for accessing repository files.
- `secrets: read` for accessing the `CODECOV_TOKEN` secret.
- `actions: read` for using GitHub Actions.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
