### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 env:
   COMPOSER_NO_INTERACTION: 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/volt-test/laravel-performance-testing/security/code-scanning/4](https://github.com/volt-test/laravel-performance-testing/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow (`actions/checkout`, `actions/cache`, etc.), the workflow likely only needs read access to the repository contents. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. Since all jobs in this workflow seem to require similar permissions, adding the block at the root level is the most efficient approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
